### PR TITLE
Consistency fix: groupId should be com.comoyo.commons

### DIFF
--- a/logging-context-json/pom.xml
+++ b/logging-context-json/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>commons</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <groupId>com.comoyo</groupId>
+  <groupId>com.comoyo.commons</groupId>
   <artifactId>logging-context-json</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>logging-context-json - Logging with context to json-event logs for logstash</name>


### PR DESCRIPTION
For some reason it was com.comoyo, which isn't consistent with the convention established in sibling components in this repository. (Modulo the pb-json thing, which is com.comoyo.protobuf, possibly for hysterical raisins, I'm not sure)
