### PR TITLE
JUL logging uncaught exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The list of components currently reads as follows:
 * [logging-context](logging-context) Structured application state/context for logging
 * [logging-context-gelf](logging-context-gelf) Context-aware GELF log handler
 * [logging-context-json](logging-context-json) Context-aware JSON/logstash log formatter
+* [logging-utilities](logging-utilities) Helpers for logging. Sensible default exception handler which logs to jul.
 * [pb-json](pb-json) Hassle-free conversion from Protobuf to JSON and back
 * [emjar](emjar) Class loader and supporting cast for using jar-in-jar embedded archives as part of classpath
 * [emjar-maven-plugin](emjar-maven-plugin) Generate EmJar-enabled bundle archives from Maven

--- a/logging-utilities/pom.xml
+++ b/logging-utilities/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>commons</artifactId>
+        <groupId>com.comoyo</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>logging-utilities</artifactId>
+</project>

--- a/logging-utilities/src/main/java/com/comoyo/commons/logging/utilities/UncaughtExceptionHandler.java
+++ b/logging-utilities/src/main/java/com/comoyo/commons/logging/utilities/UncaughtExceptionHandler.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2014 Telenor Digital AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comoyo.commons.logging.utilities;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Uncaught exception handler which logs exceptions using JUL.
+ */
+public final class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+    private static final Logger logger = Logger.getLogger(UncaughtExceptionHandler.class.getName());
+
+    private UncaughtExceptionHandler() {}
+
+    public void uncaughtException(Thread thread, Throwable throwable) {
+        if (throwable instanceof ThreadDeath) {
+            return;
+        }
+        try {
+            logger.log(Level.WARNING, "Uncaught exception in thread \""
+                    + thread.getName() + "\" ", throwable);
+        } catch (Error e) {
+            // Desperation attempt to not lose log messages, in case of error
+            // try to log it on sdterr.
+            // This logging matches the default behaviour if no UncaughtExceptionHandler
+            // is registered.
+            if (!(e instanceof ThreadDeath)) {
+                System.err.print("Exception when logging uncaught exception");
+                e.printStackTrace(System.err);
+            }
+            System.err.print("Uncaught exception in thread \""
+                    + thread.getName() + "\" ");
+            throwable.printStackTrace(System.err);
+            if (e instanceof ThreadDeath) {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Install UncaughtExceptionHandler as the default uncaught exception handler.
+     */
+    public static void install() {
+        Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>logging-context</module>
     <module>logging-context-gelf</module>
     <module>logging-context-json</module>
+    <module>logging-utilities</module>
     <module>emjar</module>
     <module>emjar-maven-plugin</module>
   </modules>


### PR DESCRIPTION
The default uncaught exception handler logs to stderr which means that uncaught exceptions
can potentially be logged outside of the context of the rest of the logs. UncaughtExceptionHandler
is a default exception handler replacement which logs using jul instead of printing directly to stderr.
In case jul logging fails stderr is used as a fallback.
