### PR TITLE
Only inspect jar artifacts.

### DIFF
--- a/emjar-maven-plugin/src/main/java/com/comoyo/maven/plugins/emjar/EmJarMojo.java
+++ b/emjar-maven-plugin/src/main/java/com/comoyo/maven/plugins/emjar/EmJarMojo.java
@@ -442,6 +442,10 @@ public class EmJarMojo
         final Artifact artifact)
         throws IOException
     {
+        final String type = artifact.getType();
+        if (!"jar".equals(type)) {
+            return;
+        }
         final File file = artifact.getFile();
         final JarFile jar = new JarFile(file);
         final Enumeration<? extends JarEntry> entries = jar.entries();


### PR DESCRIPTION
Opening e.g pom dependency artifacts as jar files causes IOExceptions.
