### PR TITLE
Don't attempt fancy encoding tests if file.encoding is substandard

### DIFF
--- a/emjar/src/test/java/com/comoyo/emjar/EmJarClassLoaderTest.java
+++ b/emjar/src/test/java/com/comoyo/emjar/EmJarClassLoaderTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.JUnit4;
 import com.google.common.base.Joiner;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 @RunWith(JUnit4.class)
 public class EmJarClassLoaderTest extends EmJarTest
@@ -100,6 +101,7 @@ public class EmJarClassLoaderTest extends EmJarTest
     public void testClassPathQuoting()
         throws Exception
     {
+        assumeTrue("UTF-8".equals(System.getProperty("file.encoding")));
         final EmJarClassLoader loader = testLoader();
         final String searchName = "entry-" + WEIRD + ".txt";
         final InputStream is = getResourceAsStreamRobust(loader, searchName);

--- a/emjar/src/test/java/com/comoyo/emjar/JarTest.java
+++ b/emjar/src/test/java/com/comoyo/emjar/JarTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 @RunWith(JUnit4.class)
 public abstract class JarTest extends EmJarTest
@@ -75,6 +76,7 @@ public abstract class JarTest extends EmJarTest
     public void testQuoting()
         throws Exception
     {
+        assumeTrue("UTF-8".equals(System.getProperty("file.encoding")));
         testJarBundle(WEIRD);
     }
 }


### PR DESCRIPTION
This resolves test breakage that is not easily fixed by other means.